### PR TITLE
Update 2020-05-27-Issue-61.md

### DIFF
--- a/_posts/2020-05-27-Issue-61.md
+++ b/_posts/2020-05-27-Issue-61.md
@@ -74,7 +74,7 @@ Ever wondered if could take Square payments in your app? You can (in fact, you a
 
 ## HAHA ― And They All Laughed
 
-Continuing with the retro gaming theme, anybody remember _[Doom](https://en.wikipedia.org/wiki/Doom_(franchise)_? OK, yeah, we know. **Everybody** remembers _Doom_.
+Continuing with the retro gaming theme, anybody remember _<a href="https://en.wikipedia.org/wiki/Doom_(franchise)">Doom</a>_? OK, yeah, we know. **Everybody** remembers _Doom_.
 
 ![](https://dragonrubydispatch.com/assets/images/the-difference-590x787.png)
 


### PR DESCRIPTION
Markdown was choking on the  '(' ')' included in the Doom wikipedia link. Simply coded the link directly in HTML.